### PR TITLE
Order created after successful payment in hosted fields

### DIFF
--- a/Dna/Payment/Api/OrderManagementInterface.php
+++ b/Dna/Payment/Api/OrderManagementInterface.php
@@ -111,6 +111,7 @@ interface OrderManagementInterface
      * @param string $paypalCaptureStatus
      * @param string $paypalCaptureStatusReason
      * @param string $paypalOrderStatus
+     * @param string $merchantCustomData
      * @return void
      */
     public function failureOrder(
@@ -129,6 +130,7 @@ interface OrderManagementInterface
         $paymentMethod = null,
         $paypalCaptureStatus = null,
         $paypalCaptureStatusReason = null,
-        $paypalOrderStatus = null
+        $paypalOrderStatus = null,
+        $merchantCustomData = null
     );
 }

--- a/Dna/Payment/Controller/Result/Failure.php
+++ b/Dna/Payment/Controller/Result/Failure.php
@@ -64,7 +64,7 @@ class Failure extends Action implements ViewInterface
         $order = $_checkoutSession->getLastRealOrder();
         $status = $order->getStatus();
 
-        if ($order->getStatus() == $order::STATE_PENDING_PAYMENT) {
+        if ($order->getId() && $status == $order::STATE_PENDING_PAYMENT) {
             try {
                 $order->cancel();
                 $this->orderRepository->save($order);

--- a/Dna/Payment/Model/OrderManagement.php
+++ b/Dna/Payment/Model/OrderManagement.php
@@ -911,10 +911,26 @@ class OrderManagement implements \Dna\Payment\Api\OrderManagementInterface
         $paymentMethod = null,
         $paypalCaptureStatus = null,
         $paypalCaptureStatusReason = null,
-        $paypalOrderStatus = null
+        $paypalOrderStatus = null,
+        $merchantCustomData = null
     )
     {
-        $order = Helpers::getOrderInfo($invoiceId);
+        $merchantCustomDataJson = json_decode($merchantCustomData ?: '{}', true);
+
+        if (isset($merchantCustomDataJson['quoteId'])) {
+            $quoteId = $merchantCustomDataJson['quoteId'];
+            $orderCollection = $this->orderCollectionFactory->create()
+                ->addFieldToFilter('quote_id', $quoteId);
+            $order = $orderCollection->getFirstItem();
+
+            if (!$order || !$order->getId()) {
+                // Order was not created (quote-based flow, payment failed before placeOrder)
+                return $invoiceId;
+            }
+            $invoiceId = $order->getIncrementId();
+        } else {
+            $order = Helpers::getOrderInfo($invoiceId);
+        }
 
         if (!$this->isDNAPaymentOrder($order)) {
             return;

--- a/Dna/Payment/view/frontend/web/js/view/payment/method-renderer/hosted-fields.js
+++ b/Dna/Payment/view/frontend/web/js/view/payment/method-renderer/hosted-fields.js
@@ -10,9 +10,11 @@ define(
         'Magento_Checkout/js/model/full-screen-loader',
         'Magento_Ui/js/model/messageList',
         'Magento_Vault/js/view/payment/vault-enabler',
+        'Magento_Checkout/js/model/quote',
+        'Dna_Payment/js/api',
         'Magento_Payment/js/view/payment/cc-form'
     ],
-    function ($, hostedFields, storage, $t, placeOrderAction, fullScreenLoader, globalMessageList, VaultEnabler, Component) {
+    function ($, hostedFields, storage, $t, placeOrderAction, fullScreenLoader, globalMessageList, VaultEnabler, quote, api, Component) {
         'use strict';
 
         return Component.extend({
@@ -20,7 +22,6 @@ define(
                 template: 'Dna_Payment/payment/form-hosted',
                 code: 'dna_payment',
                 hostedFieldsInstance: null,
-                orderId: null,
                 paymentResponse: null,
                 threeDModal: null,
             },
@@ -92,63 +93,38 @@ define(
 
                 if (await this.validate() && this.isPlaceOrderActionAllowed() === true) {
                     fullScreenLoader.startLoader();
-                    this.isPlaceOrderActionAllowed(false);
-                    this.getPlaceOrderDeferredObject().done(
-                        function (orderId) {
-                            self.orderId = orderId;
-                            if (!self.paymentResponse) {
-                                self.fetchPaymentData(orderId)
-                                    .then(async function (response) {
-                                        self.paymentResponse = response;
-                                        const {paymentData, accessToken} = response;
+                    self.isPlaceOrderActionAllowed(false);
 
-                                        try {
-                                            if (self.isVaultEnabled()) {
-                                                paymentData.merchantCustomData = JSON.stringify({
-                                                    storeCardOnFile: $('#' + self.getCode() + '_enable_vault').prop('checked')
-                                                });
-                                            }
+                    try {
+                        var quoteId = quote.getQuoteId();
+                        var response = await api.fetchQuotePaymentData(quoteId);
+                        var paymentData = response.paymentData;
+                        var accessToken = response.auth.access_token;
 
-                                            await self.hostedFieldsInstance.submit({
-                                                paymentData: paymentData,
-                                                token: accessToken
-                                            });
-                                            window.location.href = paymentData.paymentSettings.returnUrl;
-                                        } catch (error) {
-                                            console.error('Failed to submit hosted fields data:', error);
-
-                                            fullScreenLoader.stopLoader();
-                                            self.isPlaceOrderActionAllowed(true);
-
-                                            if (error.code === 'INVALID_CARD_DATA') {
-                                                console.log('INVALID_CARD_DATA');
-                                            } else {
-                                                self.hostedFieldsInstance.clear();
-                                            }
-
-                                            self.showError((error && error.message) || $t('Payment failed. Please try again.'));
-                                        }
-                                    })
-                                    .catch(function (error) {
-                                        fullScreenLoader.stopLoader();
-                                        self.isPlaceOrderActionAllowed(true);
-                                        self.showError($t('Failed to load payment data.'));
-                                    });
-                            }
-                        },
-                    ).fail(
-                        function () {
-                            console.log('Failed to placed order.');
-
-                            fullScreenLoader.stopLoader();
-                            self.isPlaceOrderActionAllowed(true);
-                            self.showError($t('Failed to place order.'));
+                        if (self.isVaultEnabled()) {
+                            var customData = JSON.parse(paymentData.merchantCustomData || '{}');
+                            customData.storeCardOnFile = $('#' + self.getCode() + '_enable_vault').prop('checked');
+                            paymentData.merchantCustomData = JSON.stringify(customData);
                         }
-                    );
 
-                    return true;
+                        await self.hostedFieldsInstance.submit({
+                            paymentData: paymentData,
+                            token: accessToken
+                        });
+
+                        await self.getPlaceOrderDeferredObject();
+
+                        window.location.href = paymentData.paymentSettings.returnUrl;
+                    } catch (error) {
+                        fullScreenLoader.stopLoader();
+                        self.isPlaceOrderActionAllowed(true);
+
+                        if (error.code !== 'INVALID_CARD_DATA' && self.hostedFieldsInstance) {
+                            self.hostedFieldsInstance.clear();
+                        }
+                        self.showError((error && error.message) || $t('Payment failed. Please try again.'));
+                    }
                 } else {
-                    console.log('Hosted fields validation failed.');
 
                     fullScreenLoader.stopLoader();
                     self.isPlaceOrderActionAllowed(true);
@@ -232,36 +208,6 @@ define(
                 };
 
                 return window.dnaPayments.hostedFields.create(config);
-            },
-
-            fetchPaymentData: function (orderId) {
-                return new Promise((resolve, reject) => {
-                    $.ajax({
-                        url: '/rest/V1/dna-payment/get-order-payment-data?orderId=' + orderId,
-                        type: 'get',
-                        success: function (res) {
-                            const {paymentData, auth, adminOrderViewUrl} = (function () {
-                                if (Array.isArray(res)) {
-                                    const [p, a, t, i, u] = res
-                                    return {
-                                        paymentData: p,
-                                        auth: a,
-                                        isTestMode: t,
-                                        integrationType: i,
-                                        adminOrderViewUrl: u
-                                    }
-                                }
-                                return res || {}
-                            })()
-                            resolve({paymentData, accessToken: auth.access_token, adminOrderViewUrl});
-                        },
-                        error: function (err) {
-                            console.error('Failed to fetch payment data:', error);
-
-                            reject(err);
-                        }
-                    })
-                })
             },
 
             /**

--- a/Dna/Payment/view/frontend/web/js/view/payment/method-renderer/hosted-fields.js
+++ b/Dna/Payment/view/frontend/web/js/view/payment/method-renderer/hosted-fields.js
@@ -83,6 +83,7 @@ define(
                 globalMessageList.addErrorMessage({
                     message: errorMessage
                 });
+                window.scrollTo({top: 0, behavior: 'smooth'});
             },
             placeOrder: async function (data, event) {
                 let self = this;


### PR DESCRIPTION
- hosted-fields.js: Rewrote placeOrder flow using api.fetchQuotePaymentData(quoteId) instead of fetchPaymentData(orderId). Removed fetchPaymentData method. Order is now placed via
   getPlaceOrderDeferredObject() only after DNA Payments confirms success.
 - OrderManagement.php / OrderManagementInterface.php: Added $merchantCustomData parameter to failureOrder. When a failure callback arrives from DNA Payments, the handler uses quoteId (embedded in merchantCustomData by the server) to locate the order — or exits early if no order was created yet.
